### PR TITLE
Allow walpha to contain spaces before pod

### DIFF
--- a/commands.yaml
+++ b/commands.yaml
@@ -2203,7 +2203,7 @@ WALPHA: |-
     use WWW::WolframAlpha;
     my( $kernel, $heap, $who, $what, $src, $dest, $replypath ) = @_;
     my $searchPod;
-    if( $what =~ '(.+)/([^/]+)$' ) {
+    if( $what =~ '(.+)/ *([^/]+)$' ) {
     	$what = $1;
     	$searchPod = $2;
     }


### PR DESCRIPTION
Currently, walpha must not contain any spaces between the final / and the pod.

Commands can look quite ugly in my opinion, such as "walpha 2 + 2 / 24 /result"

This change allows spaces to occur, for ex. "walpha 2 + 2 / 24 / result"
