### PR TITLE
irc: try to treat all IRC messages as UTF-8

### DIFF
--- a/irc.pl
+++ b/irc.pl
@@ -209,6 +209,7 @@ sub on_public {
 	# Strip color
 	$msg =~ s/(\x3)[0-9]{0,2}//g;
 	$msg =~ s/\x02//g;
+	utf8::decode( $msg ); # intentionally continue if not valid UTF-8; it will be treated as the native encoding
 	$cmd = ( split( / /, $msg, 2 ) )[0];
 	$kernel->post( "core", "core_public", $who, $msg, $self->{ "ssid" }, $dest->[0], "send_public_to", ($bridged==0), $self->{ "trapEnabled" } );
 }
@@ -219,6 +220,7 @@ sub on_private {
 	$who = (split( /!/, $who, 2 ))[0];
 	$msg =~ s/(\x3)[0-9]{0,2}//g;
 	$msg =~ s/\x02//g;
+	utf8::decode( $msg ); # intentionally continue if not valid UTF-8; it will be treated as the native encoding
 	$cmd = ( split( / /, $msg, 2 ) )[0];
 	$kernel->post( "core", "cmd", $who, $msg, $self->{ "ssid" }, $who, "send_private", 1 );
 	$kernel->post( "core", "seen", $who, $msg, $self->{ "ssid" }, $who, "send_private", 1 );


### PR DESCRIPTION
Incoming non-ASCII strings do not initially have the Perl-internal utf8 flag set, which causes the bytes to be interpreted as the default encoding (typically, Latin-1).  Normally we're firing those bytes back to IRC so it doesn't matter, but for ~define, the YAML serialization applies a second layer of UTF-8 encoding, causing the factoids to become gibberish when Destult is reloaded.

Testing done:
Using the following additional command, verified that "isutf8 á" replies "Is".

```
  ISUTF8: |-
    sub {
      use utf8;
      my( $kernel, $heap, $who, $what, $src, $dest, $replypath ) = @_;
      if( utf8::is_utf8( $what ) ) {
        $kernel->post( $src, $replypath, "Is", $dest);
      } else {
        $kernel->post( $src, $replypath, "Is not", $dest);
      }
    }
```

Verified that "define mu as µ" now puts "MU: µ" in factoids.yaml.  Previously, it would be "MU: Âµ".

Verified with Wireshark that 'ß' is sent to IRC as the bytes C3 9F, rather than DF (its Latin-1 value, and an invalid UTF-8 sequence).  I'm actually not 100% sure I understand **why** this is, since I don't see an explicit encode when sending the strings to the network.
